### PR TITLE
Add ImageForensic API project

### DIFF
--- a/ImageForensic.Api.Tests/AnalyzerEndpointsTests.cs
+++ b/ImageForensic.Api.Tests/AnalyzerEndpointsTests.cs
@@ -1,0 +1,27 @@
+using ImageForensic.Api.Models;
+using ImageForensics.Core;
+using ImageForensics.Core.Models;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Moq;
+using Xunit;
+using System.Threading.Tasks;
+
+namespace ImageForensic.Api.Tests;
+
+public class AnalyzerEndpointsTests
+{
+    [Fact]
+    public async Task AnalyzeImage_ReturnsResultFromAnalyzer()
+    {
+        var expected = new ForensicsResult(0.1, "ela", "ok", 0.2, "mask");
+        var mock = new Mock<IForensicsAnalyzer>();
+        var options = new ForensicsOptions();
+        mock.Setup(a => a.AnalyzeAsync("img.jpg", options)).ReturnsAsync(expected);
+
+        var request = new AnalyzeImageRequest("img.jpg", options);
+        var result = await AnalyzerEndpoints.AnalyzeImage(request, mock.Object);
+        var ok = Assert.IsType<Ok<ForensicsResult>>(result);
+        Assert.Equal(expected, ok.Value);
+        mock.Verify(a => a.AnalyzeAsync("img.jpg", options), Times.Once);
+    }
+}

--- a/ImageForensic.Api.Tests/ApiIntegrationTests.cs
+++ b/ImageForensic.Api.Tests/ApiIntegrationTests.cs
@@ -1,0 +1,46 @@
+using System.Linq;
+using System.Net.Http.Json;
+using ImageForensic.Api.Models;
+using ImageForensics.Core;
+using ImageForensics.Core.Models;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using System.Threading.Tasks;
+
+namespace ImageForensic.Api.Tests;
+
+public class ApiIntegrationTests
+{
+    [Fact]
+    public async Task PostAnalyze_ReturnsOkWithResult()
+    {
+        var fakeResult = new ForensicsResult(0.1, "ela", "ok", 0.2, "mask");
+        var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.Single(d => d.ServiceType == typeof(IForensicsAnalyzer));
+                services.Remove(descriptor);
+                services.AddSingleton<IForensicsAnalyzer>(new FakeAnalyzer(fakeResult));
+            });
+        });
+        var client = factory.CreateClient();
+        var request = new AnalyzeImageRequest("img.jpg", new ForensicsOptions());
+        var response = await client.PostAsJsonAsync("/analyze", request);
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<ForensicsResult>();
+        Assert.NotNull(result);
+        Assert.Equal(fakeResult.ElaScore, result!.ElaScore);
+        Assert.Equal(fakeResult.CopyMoveScore, result.CopyMoveScore);
+        Assert.Equal(fakeResult.Verdict, result.Verdict);
+    }
+
+    private class FakeAnalyzer : IForensicsAnalyzer
+    {
+        private readonly ForensicsResult _result;
+        public FakeAnalyzer(ForensicsResult result) => _result = result;
+        public Task<ForensicsResult> AnalyzeAsync(string imagePath, ForensicsOptions options)
+            => Task.FromResult(_result);
+    }
+}

--- a/ImageForensic.Api.Tests/ImageForensic.Api.Tests.csproj
+++ b/ImageForensic.Api.Tests/ImageForensic.Api.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ImageForensic.Api\ImageForensic.Api.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+  </ItemGroup>
+</Project>

--- a/ImageForensic.Api/AssemblyInfo.cs
+++ b/ImageForensic.Api/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ImageForensic.Api.Tests")]

--- a/ImageForensic.Api/Endpoints/AnalyzerEndpoints.cs
+++ b/ImageForensic.Api/Endpoints/AnalyzerEndpoints.cs
@@ -1,0 +1,23 @@
+using ImageForensic.Api.Models;
+using ImageForensics.Core;
+using ImageForensics.Core.Models;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace ImageForensic.Api;
+
+public static class AnalyzerEndpoints
+{
+    public static void MapAnalyzerEndpoints(this IEndpointRouteBuilder routes)
+    {
+        routes.MapPost("/analyze", AnalyzeImage)
+              .WithName("AnalyzeImage");
+    }
+
+    internal static async Task<IResult> AnalyzeImage(AnalyzeImageRequest request, IForensicsAnalyzer analyzer)
+    {
+        var result = await analyzer.AnalyzeAsync(request.ImagePath, request.Options);
+        return Results.Ok(result);
+    }
+}

--- a/ImageForensic.Api/ImageForensic.Api.csproj
+++ b/ImageForensic.Api/ImageForensic.Api.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ImageForensics\src\ImageForensics.Core\ImageForensics.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ImageForensic.Api/ImageForensic.Api.http
+++ b/ImageForensic.Api/ImageForensic.Api.http
@@ -1,0 +1,6 @@
+@ImageForensic.Api_HostAddress = http://localhost:5236
+
+GET {{ImageForensic.Api_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/ImageForensic.Api/Models/AnalyzeImageRequest.cs
+++ b/ImageForensic.Api/Models/AnalyzeImageRequest.cs
@@ -1,0 +1,5 @@
+using ImageForensics.Core.Models;
+
+namespace ImageForensic.Api.Models;
+
+public record AnalyzeImageRequest(string ImagePath, ForensicsOptions Options);

--- a/ImageForensic.Api/Program.cs
+++ b/ImageForensic.Api/Program.cs
@@ -1,0 +1,19 @@
+using ImageForensic.Api;
+using ImageForensics.Core;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+builder.Services.AddSingleton<IForensicsAnalyzer, ForensicsAnalyzer>();
+
+var app = builder.Build();
+
+app.UseSwagger();
+app.UseSwaggerUI();
+
+app.MapAnalyzerEndpoints();
+
+app.Run();
+
+public partial class Program { }

--- a/ImageForensic.Api/Properties/launchSettings.json
+++ b/ImageForensic.Api/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5236",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/ImageForensic.Api/appsettings.Development.json
+++ b/ImageForensic.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/ImageForensic.Api/appsettings.json
+++ b/ImageForensic.Api/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/README.md
+++ b/README.md
@@ -102,6 +102,24 @@ dotnet run --project ImageForensics/src/ImageForensics.Cli -- --benchmark-ela --
 dotnet run --project ImageForensics/src/ImageForensics.Cli -- --benchmark-all --input-dir dataset/casia2 --report-dir bench
 ```
 
+## API REST
+Il progetto `ImageForensic.Api` espone un endpoint HTTP per analizzare un'immagine tramite le stesse opzioni della libreria.
+
+### Avvio
+```bash
+dotnet run --project ImageForensic.Api/ImageForensic.Api.csproj
+```
+
+### Endpoint `/analyze`
+Richiede una richiesta `POST` con corpo JSON:
+```json
+{
+  "imagePath": "percorso/dell/immagine.jpg",
+  "options": { /* campi di ForensicsOptions */ }
+}
+```
+La risposta è un oggetto `ForensicsResult` con punteggi, mappe generate e verdetto. La documentazione Swagger è disponibile all'indirizzo `/swagger`.
+
 ### Parametri principali
 `ForensicsOptions` espone diversi parametri regolabili:
 
@@ -191,10 +209,14 @@ Il progetto `TestOpenCvSharp` verifica il corretto caricamento della libreria na
 ```bash
 dotnet test TestOpenCvSharp/TestOpenCvSharp.csproj -v n
 ```
+Il progetto `ImageForensic.Api.Tests` contiene i test per l'API REST:
+```bash
+dotnet test ImageForensic.Api.Tests/ImageForensic.Api.Tests.csproj -v n
+```
 I dataset di riferimento (CASIA2) sono collocati in `dataset/authentic` e `dataset/tampered`; altri file come `clean.png` e `inpainting.png` risiedono in `tests/ImageForensics.Tests/testdata`.
 
 
-Ultima esecuzione test: **2025-07-31** – 48 test completati con successo.
+Ultima esecuzione test: **2025-07-31** – 2 test completati con successo (`ImageForensic.Api.Tests`).
 
 ### Riepilogo test
 

--- a/image-forgery-scanner.sln
+++ b/image-forgery-scanner.sln
@@ -1,8 +1,12 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestOpenCvSharp", "TestOpenCvSharp\TestOpenCvSharp.csproj", "{8EA200B4-EFAD-A4AE-A7D0-8E0B8966E148}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImageForensic.Api", "ImageForensic.Api\ImageForensic.Api.csproj", "{E329F41C-28F7-48F5-9B30-1E5FEB18A82D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImageForensic.Api.Tests", "ImageForensic.Api.Tests\ImageForensic.Api.Tests.csproj", "{E84CD0AB-FA4A-40A2-BC79-A151267A1101}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,7 +18,15 @@ Global
 		{8EA200B4-EFAD-A4AE-A7D0-8E0B8966E148}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8EA200B4-EFAD-A4AE-A7D0-8E0B8966E148}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8EA200B4-EFAD-A4AE-A7D0-8E0B8966E148}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+		{E329F41C-28F7-48F5-9B30-1E5FEB18A82D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {E329F41C-28F7-48F5-9B30-1E5FEB18A82D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {E329F41C-28F7-48F5-9B30-1E5FEB18A82D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {E329F41C-28F7-48F5-9B30-1E5FEB18A82D}.Release|Any CPU.Build.0 = Release|Any CPU
+                {E84CD0AB-FA4A-40A2-BC79-A151267A1101}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {E84CD0AB-FA4A-40A2-BC79-A151267A1101}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {E84CD0AB-FA4A-40A2-BC79-A151267A1101}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {E84CD0AB-FA4A-40A2-BC79-A151267A1101}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add new ImageForensic.Api project targeting .NET 9
- expose `/analyze` endpoint wrapping ForensicsAnalyzer and document with Swagger
- document REST API and update test results in README
- add unit and integration tests for the API

## Testing
- `dotnet test ImageForensic.Api.Tests/ImageForensic.Api.Tests.csproj -v n`


------
https://chatgpt.com/codex/tasks/task_e_688bb4815708832596545e09bcffe4c5