### PR TITLE
Handle analysis artifacts as byte arrays

### DIFF
--- a/ImageForensic.Api/Models/AnalyzeImageRequest.cs
+++ b/ImageForensic.Api/Models/AnalyzeImageRequest.cs
@@ -1,5 +1,0 @@
-using ImageForensics.Core.Models;
-
-namespace ImageForensic.Api.Models;
-
-public record AnalyzeImageRequest(string ImagePath, ForensicsOptions Options);

--- a/ImageForensics/src/ImageForensics.Core/Models/ForensicsOptions.cs
+++ b/ImageForensics/src/ImageForensics.Core/Models/ForensicsOptions.cs
@@ -3,24 +3,17 @@ namespace ImageForensics.Core.Models;
 public record ForensicsOptions
 {
     public int ElaQuality { get; init; } = 75;
-    public string WorkDir { get; init; } = "results";
 
     public int    CopyMoveFeatureCount  { get; init; } = 5000;
     public double CopyMoveMatchDistance { get; init; } = 3.0;
     public double CopyMoveRansacReproj  { get; init; } = 3.0;
     public double CopyMoveRansacProb    { get; init; } = 0.99;
-    public string CopyMoveMaskDir       { get; init; } = "results";
 
-    public string SplicingModelPath   { get; init; } = "mantranet_256x256.onnx";
     public int    SplicingInputWidth  { get; init; } = 256;
     public int    SplicingInputHeight { get; init; } = 256;
-    public string SplicingMapDir      { get; init; } = "results";
 
-    public string NoiseprintModelsDir { get; init; } = "ImageForensics/src/Models/onnx/noiseprint";
     public int    NoiseprintInputSize { get; init; } = 320;
-    public string NoiseprintMapDir    { get; init; } = "results";
 
-    public string MetadataMapDir      { get; init; } = "results";
     public string[] ExpectedCameraModels { get; init; } = new[]
     {
         "Canon EOS 80D",

--- a/ImageForensics/src/ImageForensics.Core/Models/ForensicsResult.cs
+++ b/ImageForensics/src/ImageForensics.Core/Models/ForensicsResult.cs
@@ -1,18 +1,19 @@
+using System;
 using System.Collections.Generic;
 
 namespace ImageForensics.Core.Models;
 
 public record ForensicsResult(
     double ElaScore,
-    string ElaMapPath,
+    byte[] ElaMap,
     string Verdict,
     double CopyMoveScore,
-    string CopyMoveMaskPath)
+    byte[] CopyMoveMask)
 {
     public double SplicingScore   { get; init; }
-    public string SplicingMapPath { get; init; } = string.Empty;
+    public byte[] SplicingMap { get; init; } = Array.Empty<byte>();
     public double InpaintingScore   { get; init; }
-    public string InpaintingMapPath { get; init; } = string.Empty;
+    public byte[] InpaintingMap { get; init; } = Array.Empty<byte>();
 
     public double ExifScore { get; init; }
     public IReadOnlyDictionary<string, string?> ExifAnomalies { get; init; } = new Dictionary<string, string?>();


### PR DESCRIPTION
## Summary
- Create per-request work directory for `/analyze` and remove path parameters from `ForensicsOptions`
- Return analysis maps and masks as byte arrays in `ForensicsResult`
- Update unit and integration tests to ensure binary data is present and document new API behavior

## Testing
- `dotnet test TestOpenCvSharp/TestOpenCvSharp.csproj -v n`
- `dotnet test ImageForensic.Api.Tests/ImageForensic.Api.Tests.csproj -v n`


------
https://chatgpt.com/codex/tasks/task_e_688bbab6f8bc83258b42af44443f205c