### PR TITLE
Optimize splicing preprocessing

### DIFF
--- a/ImageForensics/src/ImageForensics.Core/Algorithms/ElaAnalyzer.cs
+++ b/ImageForensics/src/ImageForensics.Core/Algorithms/ElaAnalyzer.cs
@@ -18,11 +18,8 @@ public static class ElaAnalyzer
         using var orig = new MagickImage(imagePath);
         using var comp = orig.Clone();
         comp.Quality = quality;
-
-        using var ms = new MemoryStream();
-        comp.Write(ms, MagickFormat.Jpeg);
-        ms.Position = 0;
-        using var compReloaded = new MagickImage(ms);
+        byte[] jpeg = comp.ToByteArray(MagickFormat.Jpeg);
+        using var compReloaded = new MagickImage(jpeg);
 
         using var diff = new MagickImage();
         double score = orig.Compare(compReloaded, ErrorMetric.RootMeanSquared, diff);

--- a/ImageForensics/src/ImageForensics.Core/Algorithms/NoisePrintSdk.cs
+++ b/ImageForensics/src/ImageForensics.Core/Algorithms/NoisePrintSdk.cs
@@ -1,5 +1,6 @@
 using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -10,27 +11,19 @@ namespace ImageForensics.Core.Algorithms;
 /// </summary>
 public static class NoisePrintSdk
 {
-    private static InferenceSession? _session;
+    private static readonly ConcurrentDictionary<string, InferenceSession> Sessions = new();
 
-    /// <summary>Load the ONNX model from disk.</summary>
-    public static void LoadModel(string modelPath)
+    /// <summary>Run inference using the ONNX model at <paramref name="modelPath"/>.</summary>
+    public static float[] RunInference(string modelPath, DenseTensor<float> tensor)
     {
-        _session?.Dispose();
-        _session = new InferenceSession(modelPath);
-    }
-
-    /// <summary>Run inference using the previously loaded model.</summary>
-    public static float[] RunInference(DenseTensor<float> tensor)
-    {
-        if (_session == null)
-            throw new InvalidOperationException("Model not loaded");
+        var session = Sessions.GetOrAdd(modelPath, p => new InferenceSession(p));
 
         var inputs = new List<NamedOnnxValue>
         {
             NamedOnnxValue.CreateFromTensor("input", tensor)
         };
 
-        using var results = _session.Run(inputs);
+        using var results = session.Run(inputs);
         return results.First().AsTensor<float>().ToArray();
     }
 }


### PR DESCRIPTION
## Summary
- streamline splicing image preprocessing by resizing in place and copying pixels directly into the ONNX tensor
- document preprocessing benchmark timings before and after optimization and refresh test run timestamp
- add parallel benchmarking for the splicing detector and record sequential vs parallel timings on a 20-image dataset

## Testing
- `dotnet run --project ImageForensics/src/ImageForensics.Cli -- --benchmark-splicing --input-dir dataset/bench20 --workdir workdir_seq --report-dir report_seq --parallel-images 1`
- `dotnet run --project ImageForensics/src/ImageForensics.Cli -- --benchmark-splicing --input-dir dataset/bench20 --workdir workdir_par --report-dir report_par --parallel-images 4`
- `dotnet test TestOpenCvSharp/TestOpenCvSharp.csproj -v n`
- `dotnet test ImageForensic.Api.Tests/ImageForensic.Api.Tests.csproj -v n`
- `dotnet test ImageForensics/tests/ImageForensics.Tests/ImageForensics.Tests.csproj -v n`


------
https://chatgpt.com/codex/tasks/task_e_688bd97561848325a06cd1936cf5563b