### PR TITLE
Configure HttpClientFactory for Blazor page

### DIFF
--- a/ImageForensic.Api/Pages/Index.razor
+++ b/ImageForensic.Api/Pages/Index.razor
@@ -1,6 +1,7 @@
 @page "/"
 
 @inject HttpClient Http
+@inject NavigationManager Navigation
 
 <PageTitle>Analisi immagine</PageTitle>
 
@@ -282,6 +283,11 @@
     private string? splicingMap;
     private string? inpaintingMap;
     private string enabledChecks = "Ela,CopyMove,Splicing,Inpainting,Exif";
+
+    protected override void OnInitialized()
+    {
+        Http.BaseAddress = new Uri(Navigation.BaseUri);
+    }
 
     private void OnFileChange(Microsoft.AspNetCore.Components.Forms.InputFileChangeEventArgs e) => image = e.File;
 

--- a/ImageForensic.Api/Program.cs
+++ b/ImageForensic.Api/Program.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Globalization;
+using System.Net.Http;
+using Microsoft.AspNetCore.Components;
 using AntDesign;
 using ImageForensic.Api;
 using ImageForensics.Core;
@@ -11,6 +14,7 @@ builder.Services.AddSingleton<IForensicsAnalyzer, ForensicsAnalyzer>();
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
 builder.Services.AddAntDesign();
+builder.Services.AddHttpClient();
 
 var app = builder.Build();
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ dotnet test ImageForensic.Api.Tests/ImageForensic.Api.Tests.csproj -v n
 I dataset di riferimento (CASIA2) sono collocati in `dataset/authentic` e `dataset/tampered`; altri file come `clean.png` e `inpainting.png` risiedono in `tests/ImageForensics.Tests/testdata`.
 
 
-Ultima esecuzione test: **2025-08-01 06:41 UTC** – superati `TestOpenCvSharp` (2 test), `ImageForensic.Api.Tests` (4 test) e `ImageForensics.Tests` (46 test).
+Ultima esecuzione test: **2025-08-01 08:26 UTC** – superati `TestOpenCvSharp` (2 test), `ImageForensic.Api.Tests` (4 test) e `ImageForensics.Tests` (1 test).
 
 ### Riepilogo test
 


### PR DESCRIPTION
## Summary
- register HttpClient using HttpClientFactory
- set HttpClient BaseAddress from NavigationManager in Blazor page
- document latest test run

## Testing
- `dotnet test ImageForensics/tests/ImageForensics.Tests/ImageForensics.Tests.csproj -v n --filter "FullyQualifiedName~UnitTest1"`
- `dotnet test TestOpenCvSharp/TestOpenCvSharp.csproj -v n`
- `dotnet test ImageForensic.Api.Tests/ImageForensic.Api.Tests.csproj -v n`


------
https://chatgpt.com/codex/tasks/task_e_688c74a4ab4483259a6470ac1cd655eb