### PR TITLE
fix: bind enabled checks

### DIFF
--- a/ImageForensic.Api/Pages/Index.razor
+++ b/ImageForensic.Api/Pages/Index.razor
@@ -202,7 +202,7 @@
                 <FormItem Required Name="EnabledChecks">
                     <LabelTemplate>@BuildLabel("Controlli", "Elenco di controlli abilitati (ela,copymove,splicing,inpainting,exif)")</LabelTemplate>
                     <ChildContent>
-                        <AntDesign.Input @bind-Value="enabledChecks" />
+                        <AntDesign.Input @bind-Value="model.EnabledChecks" />
                     </ChildContent>
                 </FormItem>
             </Col>
@@ -282,7 +282,6 @@
     private string? copyMoveMap;
     private string? splicingMap;
     private string? inpaintingMap;
-    private string enabledChecks = "Ela,CopyMove,Splicing,Inpainting,Exif";
 
     protected override void OnInitialized()
     {
@@ -321,7 +320,7 @@
         using var content = new MultipartFormDataContent();
         content.Add(new StreamContent(image.OpenReadStream(long.MaxValue)), "image", image.Name);
 
-        var opts = model.ToOptions(enabledChecks);
+        var opts = model.ToOptions();
         content.Add(new StringContent(opts.ElaQuality.ToString(System.Globalization.CultureInfo.InvariantCulture)), nameof(opts.ElaQuality));
         content.Add(new StringContent(opts.CopyMoveFeatureCount.ToString()), nameof(opts.CopyMoveFeatureCount));
         content.Add(new StringContent(opts.CopyMoveMatchDistance.ToString(System.Globalization.CultureInfo.InvariantCulture)), nameof(opts.CopyMoveMatchDistance));
@@ -372,11 +371,12 @@
         [Required] public double CleanThreshold { get; set; } = 0.2;
         [Required] public double TamperedThreshold { get; set; } = 0.8;
         [Required] public int MaxParallelChecks { get; set; } = 1;
+        [Required] public string EnabledChecks { get; set; } = "Ela,CopyMove,Splicing,Inpainting,Exif";
 
-        public AnalyzeImageOptions ToOptions(string checks)
+        public AnalyzeImageOptions ToOptions()
         {
-            var enabled = checks.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                                 .Aggregate(ForensicsCheck.None, (a, c) => a | Enum.Parse<ForensicsCheck>(c, true));
+            var enabled = EnabledChecks.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                                       .Aggregate(ForensicsCheck.None, (a, c) => a | Enum.Parse<ForensicsCheck>(c, true));
             return new AnalyzeImageOptions
             {
                 ElaQuality = ElaQuality,


### PR DESCRIPTION
## Summary
- bind EnabledChecks field to the form model so options are parsed correctly

## Testing
- `dotnet test TestOpenCvSharp/TestOpenCvSharp.csproj -v n`
- `dotnet test ImageForensic.Api.Tests/ImageForensic.Api.Tests.csproj -v n`
- `curl -I http://localhost:5236/`

------
https://chatgpt.com/codex/tasks/task_e_688c7d668e888325948c97ecc9f03d4c