### PR TITLE
refactor: register httpclient and drop navigation injection

### DIFF
--- a/ImageForensic.Api/Pages/Index.razor
+++ b/ImageForensic.Api/Pages/Index.razor
@@ -1,7 +1,6 @@
 @page "/"
 
 @inject HttpClient Http
-@inject NavigationManager Navigation
 
 <PageTitle>Analisi immagine</PageTitle>
 
@@ -282,11 +281,6 @@
     private string? copyMoveMap;
     private string? splicingMap;
     private string? inpaintingMap;
-
-    protected override void OnInitialized()
-    {
-        Http.BaseAddress = new Uri(Navigation.BaseUri);
-    }
 
     private void OnFileChange(Microsoft.AspNetCore.Components.Forms.InputFileChangeEventArgs e) => image = e.File;
 

--- a/ImageForensic.Api/Program.cs
+++ b/ImageForensic.Api/Program.cs
@@ -15,8 +15,9 @@ builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
 builder.Services.AddAntDesign();
 
+// Register an HttpClient that points to the app's base URI so that
+// Razor components can issue relative HTTP requests without errors.
 builder.Services.AddHttpClient();
-
 builder.Services.AddScoped(sp =>
 {
     var navigationManager = sp.GetRequiredService<NavigationManager>();


### PR DESCRIPTION
## Summary
- register HttpClient in DI using app base URI
- remove unnecessary NavigationManager injection from Index page

## Testing
- `curl -I http://localhost:5236/`
- `dotnet test TestOpenCvSharp/TestOpenCvSharp.csproj -v n`
- `dotnet test ImageForensic.Api.Tests/ImageForensic.Api.Tests.csproj -v n`


------
https://chatgpt.com/codex/tasks/task_e_688c81a6f6e483258dcbe2134d7a16c8