### PR TITLE
fix: ensure HttpClient is registered

### DIFF
--- a/ImageForensic.Api/Program.cs
+++ b/ImageForensic.Api/Program.cs
@@ -18,7 +18,7 @@ builder.Services.AddAntDesign();
 // Register an HttpClient that points to the app's base URI so that
 // Razor components can issue relative HTTP requests without errors.
 builder.Services.AddHttpClient();
-builder.Services.AddScoped(sp =>
+builder.Services.AddScoped<HttpClient>(sp =>
 {
     var navigationManager = sp.GetRequiredService<NavigationManager>();
     return new HttpClient { BaseAddress = new Uri(navigationManager.BaseUri) };


### PR DESCRIPTION
## Summary
- register HttpClient explicitly so Razor pages can send relative requests

## Testing
- `curl -I http://localhost:5236/`
- `dotnet test TestOpenCvSharp/TestOpenCvSharp.csproj -v n`


------
https://chatgpt.com/codex/tasks/task_e_688c856de82483259427ae8ba91df553