### PR TITLE
Configure Serilog console logging for API

### DIFF
--- a/ImageForensic.Api/ImageForensic.Api.csproj
+++ b/ImageForensic.Api/ImageForensic.Api.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.11.0.20250507" />
     <PackageReference Include="OpenCvSharp4.Windows" Version="4.11.0.20250507" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ImageForensic.Api/Program.cs
+++ b/ImageForensic.Api/Program.cs
@@ -2,8 +2,14 @@ using System;
 using System.Globalization;
 using ImageForensic.Api;
 using ImageForensics.Core;
+using Serilog;
+
+Log.Logger = new LoggerConfiguration()
+    .WriteTo.Console()
+    .CreateLogger();
 
 var builder = WebApplication.CreateBuilder(args);
+builder.Host.UseSerilog();
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
@@ -26,5 +32,7 @@ app.MapAnalyzerEndpoints();
 app.MapRazorPages();
 
 app.Run();
+
+Log.CloseAndFlush();
 
 public partial class Program { }


### PR DESCRIPTION
## Summary
- configure Serilog to log to console in API startup
- add Serilog.AspNetCore package reference

## Testing
- `dotnet test TestOpenCvSharp/TestOpenCvSharp.csproj -v n`
- `dotnet test ImageForensic.Api.Tests/ImageForensic.Api.Tests.csproj -v n`


------
https://chatgpt.com/codex/tasks/task_e_688cb48c7cd083258ac905765802d388