### PR TITLE
Ensure image upload is validated before analysis

### DIFF
--- a/ImageForensic.Api/Endpoints/AnalyzerEndpoints.cs
+++ b/ImageForensic.Api/Endpoints/AnalyzerEndpoints.cs
@@ -18,8 +18,11 @@ public static class AnalyzerEndpoints
               .DisableAntiforgery();
     }
 
-    internal static async Task<IResult> AnalyzeImage(IFormFile image, [FromForm] AnalyzeImageOptions? options, IForensicsAnalyzer analyzer)
+    internal static async Task<IResult> AnalyzeImage([FromForm] IFormFile? image, [FromForm] AnalyzeImageOptions? options, IForensicsAnalyzer analyzer)
     {
+        if (image is null)
+            return Results.BadRequest("Missing image");
+
         options ??= new AnalyzeImageOptions();
 
         var tempFile = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}{Path.GetExtension(image.FileName)}");


### PR DESCRIPTION
## Summary
- Handle missing file upload when calling analysis endpoint

## Testing
- `dotnet test ImageForensic.Api.Tests/ImageForensic.Api.Tests.csproj -v n`
- `dotnet test TestOpenCvSharp/TestOpenCvSharp.csproj -v n`


------
https://chatgpt.com/codex/tasks/task_e_688cb4ef51cc8325880774d22d1b466b