### PR TITLE
Improve logging and error handling for forensic checks

### DIFF
--- a/ImageForensic.Api/Pages/Index.cshtml.cs
+++ b/ImageForensic.Api/Pages/Index.cshtml.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using ImageForensics.Core;
 using ImageForensics.Core.Models;
+using Serilog;
 
 namespace ImageForensic.Api.Pages;
 
@@ -74,10 +75,14 @@ public class IndexModel : PageModel
             SplicingMapBase64 = Convert.ToBase64String(Result.SplicingMap);
             InpaintingMapBase64 = Convert.ToBase64String(Result.InpaintingMap);
         }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error analyzing image");
+        }
         finally
         {
-            try { System.IO.File.Delete(tempFile); } catch { }
-            try { Directory.Delete(workDir, true); } catch { }
+            try { System.IO.File.Delete(tempFile); } catch (Exception ex) { Log.Error(ex, "Error deleting temp file"); }
+            try { Directory.Delete(workDir, true); } catch (Exception ex) { Log.Error(ex, "Error deleting work dir"); }
         }
 
         return Page();


### PR DESCRIPTION
## Summary
- add shared RunAsync helper that logs start, end and exceptions for each check
- wrap analyzer checks and page handler operations in try/catch to continue on failure

## Testing
- `dotnet test` *(fails: Program type missing in ImageForensic.Api.Tests)*
- `dotnet test TestOpenCvSharp/TestOpenCvSharp.csproj -v n`


------
https://chatgpt.com/codex/tasks/task_e_688cba5ee5088325a7feed4a0bdca783