### PR TITLE
Handle missing splicing model gracefully

### DIFF
--- a/ImageForensics/src/ImageForensics.Core/Algorithms/DlSplicingDetector.cs
+++ b/ImageForensics/src/ImageForensics.Core/Algorithms/DlSplicingDetector.cs
@@ -38,6 +38,12 @@ namespace ImageForensics.Core.Algorithms
             if (!Directory.Exists(mapDir))
                 Directory.CreateDirectory(mapDir);
 
+            if (!File.Exists(modelPath))
+            {
+                Log.Warning("Splicing model not found: {ModelPath}", modelPath);
+                return (0d, string.Empty);
+            }
+
             var sw = Stopwatch.StartNew();
             Log.Information("Splicing analysis for {Image}", imagePath);
 


### PR DESCRIPTION
## Summary
- Avoid crashing splicing analysis when the ManTraNet ONNX model file is absent

## Testing
- `dotnet test TestOpenCvSharp/TestOpenCvSharp.csproj -v n`
- `dotnet test ImageForensics/tests/ImageForensics.Tests/ImageForensics.Tests.csproj -v n` *(fails: 8 failed)*

------
https://chatgpt.com/codex/tasks/task_e_688cc703b9508325b17a123db0c7102a