### PR TITLE
Specify JPEG format before ELA compression

### DIFF
--- a/ImageForensics/src/ImageForensics.Core/Algorithms/ElaAnalyzer.cs
+++ b/ImageForensics/src/ImageForensics.Core/Algorithms/ElaAnalyzer.cs
@@ -22,8 +22,9 @@ public static class ElaAnalyzer
         Log.Debug("Cloning image and setting quality to {Quality}", quality);
         using var comp = orig.Clone();
         comp.Quality = quality;
+        comp.Format = MagickFormat.Jpeg;
         Log.Debug("Encoding image to JPEG");
-        byte[] jpeg = comp.ToByteArray(MagickFormat.Jpeg);
+        byte[] jpeg = comp.ToByteArray();
         Log.Debug("Reloading compressed image for comparison");
         using var compReloaded = new MagickImage(jpeg);
 


### PR DESCRIPTION
## Summary
- set `comp.Format = MagickFormat.Jpeg` before ELA compression to ensure JPEG output

## Testing
- `dotnet test TestOpenCvSharp/TestOpenCvSharp.csproj -v n`


------
https://chatgpt.com/codex/tasks/task_e_688ccb0c4c58832588e0de5fe28bf910