### PR TITLE
fix: remove FromForm attribute from file input

### DIFF
--- a/ImageForensic.Api/Endpoints/AnalyzerEndpoints.cs
+++ b/ImageForensic.Api/Endpoints/AnalyzerEndpoints.cs
@@ -18,7 +18,7 @@ public static class AnalyzerEndpoints
               .DisableAntiforgery();
     }
 
-    internal static async Task<IResult> AnalyzeImage([FromForm] IFormFile? image, [FromForm] AnalyzeImageOptions? options, IForensicsAnalyzer analyzer)
+    internal static async Task<IResult> AnalyzeImage(IFormFile? image, [FromForm] AnalyzeImageOptions? options, IForensicsAnalyzer analyzer)
     {
         if (image is null)
             return Results.BadRequest("Missing image");


### PR DESCRIPTION
## Summary
- remove FromForm attribute from IFormFile parameter in AnalyzeImage endpoint to fix Swagger generation

## Testing
- `dotnet test TestOpenCvSharp/TestOpenCvSharp.csproj -v n`
- `dotnet test ImageForensic.Api.Tests/ImageForensic.Api.Tests.csproj -v n`


------
https://chatgpt.com/codex/tasks/task_e_688cd136a8088325a6a64c8e682f9798