### PR TITLE
Handle Noiseprint inference errors and timeout

### DIFF
--- a/ImageForensics/tests/ImageForensics.Tests/ErrorHandlingTests.cs
+++ b/ImageForensics/tests/ImageForensics.Tests/ErrorHandlingTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using ImageForensics.Core;
@@ -18,5 +19,25 @@ public class ErrorHandlingTests
         var result = await analyzer.AnalyzeAsync("missing.jpg", options);
         Assert.Contains("ELA", result.Errors.Keys);
         Assert.Contains("EXIF", result.Errors.Keys);
+    }
+
+    [Fact]
+    public async Task InpaintingFailureIsReported()
+    {
+        var analyzer = new ForensicsAnalyzer();
+        string workDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(workDir);
+        var options = new ForensicsOptions
+        {
+            WorkDir = workDir,
+            NoiseprintMapDir = workDir,
+            NoiseprintModelsDir = Path.Combine(workDir, "missingModels"),
+            EnabledChecks = ForensicsCheck.Inpainting
+        };
+
+        string img = Path.Combine(AppContext.BaseDirectory, "testdata", "clean.png");
+        var result = await analyzer.AnalyzeAsync(img, options);
+
+        Assert.Contains("Inpainting", result.Errors.Keys);
     }
 }


### PR DESCRIPTION
## Summary
- add timeout and error propagation around NoisePrint inference to avoid hanging
- report inpainting inference failures as errors
- test that analyzer collects inpainting errors

## Testing
- `dotnet test TestOpenCvSharp/TestOpenCvSharp.csproj -v n`
- `dotnet test ImageForensics/tests/ImageForensics.Tests/ImageForensics.Tests.csproj -v n` *(fails: CliBenchmarkTests.Benchmark_All_Generates_Report, DeepfakeDatasetTests.Process_Deepfake_Dataset, NoiseprintModelSelectionTests.Run_Jpeg_LoadsQualitySpecificModel, NoiseprintModelSelectionTests.Run_Png_LoadsDefaultModel)*
- `dotnet test ImageForensics/tests/ImageForensics.Tests/ImageForensics.Tests.csproj -v n --filter "ErrorHandlingTests"`


------
https://chatgpt.com/codex/tasks/task_e_688cd3953d9483259699668a9fd83dcf