### PR TITLE
Use checkboxes to select forensic checks and show analysis loader

### DIFF
--- a/ImageForensic.Api/Models/AnalyzeImageOptions.cs
+++ b/ImageForensic.Api/Models/AnalyzeImageOptions.cs
@@ -11,16 +11,10 @@ public record AnalyzeImageOptions
     public double CopyMoveRansacReproj { get; init; } = 3.0;
     public double CopyMoveRansacProb { get; init; } = 0.99;
 
-    public int SplicingInputWidth { get; init; } = 256;
-    public int SplicingInputHeight { get; init; } = 256;
-
-    public int NoiseprintInputSize { get; init; } = 320;
-
     public string[] ExpectedCameraModels { get; init; } = new[] { "Canon EOS 80D", "Nikon D850" };
 
     public double ElaWeight { get; init; } = 1.0;
     public double CopyMoveWeight { get; init; } = 1.0;
-    public double SplicingWeight { get; init; } = 1.0;
     public double InpaintingWeight { get; init; } = 1.0;
     public double ExifWeight { get; init; } = 1.0;
 
@@ -37,13 +31,9 @@ public record AnalyzeImageOptions
         CopyMoveMatchDistance = CopyMoveMatchDistance,
         CopyMoveRansacReproj = CopyMoveRansacReproj,
         CopyMoveRansacProb = CopyMoveRansacProb,
-        SplicingInputWidth = SplicingInputWidth,
-        SplicingInputHeight = SplicingInputHeight,
-        NoiseprintInputSize = NoiseprintInputSize,
         ExpectedCameraModels = ExpectedCameraModels,
         ElaWeight = ElaWeight,
         CopyMoveWeight = CopyMoveWeight,
-        SplicingWeight = SplicingWeight,
         InpaintingWeight = InpaintingWeight,
         ExifWeight = ExifWeight,
         CleanThreshold = CleanThreshold,

--- a/ImageForensic.Api/Pages/Index.cshtml
+++ b/ImageForensic.Api/Pages/Index.cshtml
@@ -1,29 +1,45 @@
 @page
 @model ImageForensic.Api.Pages.IndexModel
+@using ImageForensics.Core.Models
+@using System.Collections.Generic
+@using System.Linq
 <!DOCTYPE html>
 <html lang="it">
 <head>
     <meta charset="utf-8" />
     <title>Analisi immagine</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" />
     <link rel="stylesheet" href="/css/site.css" />
 </head>
 <body class="bg-light">
 <div class="container py-5">
     <h1 class="mb-4 text-center">Analisi immagine</h1>
     <div class="mb-4">
-        <button class="btn btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#soglieDefault" aria-expanded="false" aria-controls="soglieDefault">
-            Mostra valori soglia di default
+        <button class="btn btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#defaultValues" aria-expanded="false" aria-controls="defaultValues">
+            Mostra valori di default
         </button>
-        <div class="collapse mt-2" id="soglieDefault">
+        <div class="collapse mt-2" id="defaultValues">
             <div class="card card-body">
                 <table class="table table-sm mb-0">
                     <thead>
-                        <tr><th>Tipo</th><th>Valore</th></tr>
+                        <tr><th>Opzione</th><th>Valore</th></tr>
                     </thead>
                     <tbody>
-                        <tr><td>Soglia pulita</td><td>@Model.DefaultCleanThreshold</td></tr>
-                        <tr><td>Soglia manomessa</td><td>@Model.DefaultTamperedThreshold</td></tr>
+                        <tr><td>ELA quality</td><td>@Model.DefaultOptions.ElaQuality</td></tr>
+                        <tr><td>Copy-Move feature count</td><td>@Model.DefaultOptions.CopyMoveFeatureCount</td></tr>
+                        <tr><td>Copy-Move match distance</td><td>@Model.DefaultOptions.CopyMoveMatchDistance</td></tr>
+                        <tr><td>Copy-Move RANSAC reprojection</td><td>@Model.DefaultOptions.CopyMoveRansacReproj</td></tr>
+                        <tr><td>Copy-Move RANSAC probability</td><td>@Model.DefaultOptions.CopyMoveRansacProb</td></tr>
+                        <tr><td>Expected camera models</td><td>@string.Join(", ", Model.DefaultOptions.ExpectedCameraModels)</td></tr>
+                        <tr><td>ELA weight</td><td>@Model.DefaultOptions.ElaWeight</td></tr>
+                        <tr><td>Copy-Move weight</td><td>@Model.DefaultOptions.CopyMoveWeight</td></tr>
+                        <tr><td>Inpainting weight</td><td>@Model.DefaultOptions.InpaintingWeight</td></tr>
+                        <tr><td>Metadata weight</td><td>@Model.DefaultOptions.ExifWeight</td></tr>
+                        <tr><td>Clean threshold</td><td>@Model.DefaultOptions.CleanThreshold</td></tr>
+                        <tr><td>Tampered threshold</td><td>@Model.DefaultOptions.TamperedThreshold</td></tr>
+                        <tr><td>Enabled checks</td><td>@string.Join(", ", Model.DefaultOptions.EnabledChecks.Select(c => c == "Exif" ? "Metadata" : c))</td></tr>
+                        <tr><td>Max parallel checks</td><td>@Model.DefaultOptions.MaxParallelChecks</td></tr>
                     </tbody>
                 </table>
             </div>
@@ -31,114 +47,121 @@
     </div>
     <form method="post" enctype="multipart/form-data" class="mb-5">
         <div class="mb-3">
-            <label class="form-label" asp-for="Image">Immagine</label>
+            <label class="form-label" asp-for="Image">Immagine <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Upload the image to analyze."></i></label>
             <input class="form-control" asp-for="Image" type="file" />
         </div>
 
         <div class="card mb-3">
-            <div class="card-header">Controllo ELA</div>
+            <div class="card-header">ELA <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Error Level Analysis highlights areas with inconsistent compression levels."></i></div>
             <div class="card-body">
                 <div class="mb-3">
-                    <label class="form-label" asp-for="Options.ElaQuality"></label>
+                    <label class="form-label" asp-for="Options.ElaQuality">
+                        <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="JPEG re-save quality used for the analysis."></i>
+                    </label>
                     <input class="form-control" asp-for="Options.ElaQuality" type="number" />
                 </div>
             </div>
         </div>
 
         <div class="card mb-3">
-            <div class="card-header">Controllo copia e sposta</div>
+            <div class="card-header">Copy-Move <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Detects duplicated regions that may indicate copy-move tampering."></i></div>
             <div class="card-body">
                 <div class="mb-3">
-                    <label class="form-label" asp-for="Options.CopyMoveFeatureCount"></label>
+                    <label class="form-label" asp-for="Options.CopyMoveFeatureCount">
+                        <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Number of keypoints used for matching."></i>
+                    </label>
                     <input class="form-control" asp-for="Options.CopyMoveFeatureCount" type="number" />
                 </div>
                 <div class="mb-3">
-                    <label class="form-label" asp-for="Options.CopyMoveMatchDistance"></label>
+                    <label class="form-label" asp-for="Options.CopyMoveMatchDistance">
+                        <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Maximum distance between matched keypoints."></i>
+                    </label>
                     <input class="form-control" asp-for="Options.CopyMoveMatchDistance" type="number" step="0.1" />
                 </div>
                 <div class="mb-3">
-                    <label class="form-label" asp-for="Options.CopyMoveRansacReproj"></label>
+                    <label class="form-label" asp-for="Options.CopyMoveRansacReproj">
+                        <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="RANSAC reprojection threshold."></i>
+                    </label>
                     <input class="form-control" asp-for="Options.CopyMoveRansacReproj" type="number" step="0.1" />
                 </div>
                 <div class="mb-3">
-                    <label class="form-label" asp-for="Options.CopyMoveRansacProb"></label>
+                    <label class="form-label" asp-for="Options.CopyMoveRansacProb">
+                        <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="RANSAC success probability."></i>
+                    </label>
                     <input class="form-control" asp-for="Options.CopyMoveRansacProb" type="number" step="0.01" />
                 </div>
             </div>
         </div>
 
+
         <div class="card mb-3">
-            <div class="card-header">Controllo giunzione</div>
+            <div class="card-header">Metadata <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Checks for camera model anomalies in EXIF metadata."></i></div>
             <div class="card-body">
-                <div class="mb-3">
-                    <label class="form-label" asp-for="Options.SplicingInputWidth"></label>
-                    <input class="form-control" asp-for="Options.SplicingInputWidth" type="number" />
-                </div>
-                <div class="mb-3">
-                    <label class="form-label" asp-for="Options.SplicingInputHeight"></label>
-                    <input class="form-control" asp-for="Options.SplicingInputHeight" type="number" />
-                </div>
+                <label class="form-label" asp-for="Options.ExpectedCameraModels">
+                    <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Select the expected camera models."></i>
+                </label>
+                @foreach (var cam in Model.AvailableCameraModels)
+                {
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="cam-@cam" name="Options.ExpectedCameraModels" value="@cam" @(Model.Options.ExpectedCameraModels?.Contains(cam) == true ? "checked" : "") />
+                        <label class="form-check-label" for="cam-@cam">@cam</label>
+                    </div>
+                }
             </div>
         </div>
 
         <div class="card mb-3">
-            <div class="card-header">Controllo impronta di rumore</div>
-            <div class="card-body">
-                <div class="mb-3">
-                    <label class="form-label" asp-for="Options.NoiseprintInputSize"></label>
-                    <input class="form-control" asp-for="Options.NoiseprintInputSize" type="number" />
-                </div>
-            </div>
-        </div>
-
-        <div class="card mb-3">
-            <div class="card-header">Metadati</div>
-            <div class="card-body">
-                <div class="mb-3">
-                    <label class="form-label" asp-for="Options.ExpectedCameraModels"></label>
-                    <input class="form-control" asp-for="Options.ExpectedCameraModels" />
-                </div>
-            </div>
-        </div>
-
-        <div class="card mb-3">
-            <div class="card-header">Pesi</div>
+            <div class="card-header">Pesi <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Weights used when combining individual scores."></i></div>
             <div class="card-body">
                 <div class="row g-3">
-                    <div class="col-md-4">
-                        <label class="form-label" asp-for="Options.ElaWeight"></label>
-                        <input class="form-control" asp-for="Options.ElaWeight" type="number" step="0.1" />
+                    <div class="col-md-6">
+                        <label class="form-label" asp-for="Options.ElaWeight">
+                            <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Weight of the ELA check."></i>
+                        </label>
+                        <input class="form-range" asp-for="Options.ElaWeight" type="range" min="0" max="1" step="0.01" oninput="document.getElementById('ElaWeightValue').textContent = this.value" />
+                        <div><span id="ElaWeightValue">@Model.Options.ElaWeight</span></div>
                     </div>
-                    <div class="col-md-4">
-                        <label class="form-label" asp-for="Options.CopyMoveWeight"></label>
-                        <input class="form-control" asp-for="Options.CopyMoveWeight" type="number" step="0.1" />
+                    <div class="col-md-6">
+                        <label class="form-label" asp-for="Options.CopyMoveWeight">
+                            <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Weight of the Copy-Move check."></i>
+                        </label>
+                        <input class="form-range" asp-for="Options.CopyMoveWeight" type="range" min="0" max="1" step="0.01" oninput="document.getElementById('CopyMoveWeightValue').textContent = this.value" />
+                        <div><span id="CopyMoveWeightValue">@Model.Options.CopyMoveWeight</span></div>
                     </div>
-                    <div class="col-md-4">
-                        <label class="form-label" asp-for="Options.SplicingWeight"></label>
-                        <input class="form-control" asp-for="Options.SplicingWeight" type="number" step="0.1" />
+                    <div class="col-md-6">
+                        <label class="form-label" asp-for="Options.InpaintingWeight">
+                            <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Weight of the Inpainting check."></i>
+                        </label>
+                        <input class="form-range" asp-for="Options.InpaintingWeight" type="range" min="0" max="1" step="0.01" oninput="document.getElementById('InpaintingWeightValue').textContent = this.value" />
+                        <div><span id="InpaintingWeightValue">@Model.Options.InpaintingWeight</span></div>
                     </div>
-                    <div class="col-md-4">
-                        <label class="form-label" asp-for="Options.InpaintingWeight"></label>
-                        <input class="form-control" asp-for="Options.InpaintingWeight" type="number" step="0.1" />
-                    </div>
-                    <div class="col-md-4">
-                        <label class="form-label" asp-for="Options.ExifWeight"></label>
-                        <input class="form-control" asp-for="Options.ExifWeight" type="number" step="0.1" />
+                    <div class="col-md-6">
+                        <label class="form-label" asp-for="Options.ExifWeight">
+                            <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Weight of the EXIF check."></i>
+                        </label>
+                        <input class="form-range" asp-for="Options.ExifWeight" type="range" min="0" max="1" step="0.01" oninput="document.getElementById('ExifWeightValue').textContent = this.value" />
+                        <div><span id="ExifWeightValue">@Model.Options.ExifWeight</span></div>
                     </div>
                 </div>
             </div>
         </div>
 
         <div class="card mb-3">
-            <div class="card-header">Soglie</div>
+            <div class="card-header">Soglie <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Thresholds separating clean and tampered scores."></i></div>
             <div class="card-body row g-3">
                 <div class="col-md-6">
-                    <label class="form-label" asp-for="Options.CleanThreshold"></label>
-                    <input class="form-control" asp-for="Options.CleanThreshold" type="number" step="0.01" />
+                    <label class="form-label" asp-for="Options.CleanThreshold">
+                        <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Scores below this value are considered clean."></i>
+                    </label>
+                    <input class="form-range" asp-for="Options.CleanThreshold" type="range" min="0" max="1" step="0.01" oninput="document.getElementById('CleanThresholdValue').textContent = this.value" />
+                    <div><span id="CleanThresholdValue">@Model.Options.CleanThreshold</span></div>
                 </div>
                 <div class="col-md-6">
-                    <label class="form-label" asp-for="Options.TamperedThreshold"></label>
-                    <input class="form-control" asp-for="Options.TamperedThreshold" type="number" step="0.01" />
+                    <label class="form-label" asp-for="Options.TamperedThreshold">
+                        <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Scores above this value indicate tampering."></i>
+                    </label>
+                    <input class="form-range" asp-for="Options.TamperedThreshold" type="range" min="0" max="1" step="0.01" oninput="document.getElementById('TamperedThresholdValue').textContent = this.value" />
+                    <div><span id="TamperedThresholdValue">@Model.Options.TamperedThreshold</span></div>
                 </div>
             </div>
         </div>
@@ -147,50 +170,79 @@
             <div class="card-header">Altre opzioni</div>
             <div class="card-body row g-3">
                 <div class="col-md-6">
-                    <label class="form-label" asp-for="Options.EnabledChecks"></label>
-                    <input class="form-control" asp-for="Options.EnabledChecks" />
+                    @{ var checkDescriptions = new Dictionary<ForensicsCheck, string>
+                        {
+                            { ForensicsCheck.Ela, "Error Level Analysis highlights compression inconsistencies." },
+                            { ForensicsCheck.CopyMove, "Detects duplicated regions from copy-move operations." },
+                            { ForensicsCheck.Inpainting, "Looks for traces of inpainting." },
+                            { ForensicsCheck.Exif, "Analyzes image metadata for anomalies." }
+                        }; }
+                    <label class="form-label">Enabled checks <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Select which analyses to run."></i></label>
+                    @foreach (var check in Enum.GetValues<ForensicsCheck>())
+                    {
+                        if (check == ForensicsCheck.None || check == ForensicsCheck.All || check == ForensicsCheck.Splicing)
+                        {
+                            continue;
+                        }
+                        var label = check == ForensicsCheck.Exif ? "Metadata" : check.ToString();
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" id="check-@check" name="Options.EnabledChecks" value="@check" @(Model.Options.EnabledChecks?.Contains(check.ToString()) == true ? "checked" : "") />
+                            <label class="form-check-label" for="check-@check">@label</label>
+                            <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="@checkDescriptions[check]"></i>
+                        </div>
+                    }
                 </div>
                 <div class="col-md-6">
-                    <label class="form-label" asp-for="Options.MaxParallelChecks"></label>
+                    <label class="form-label" asp-for="Options.MaxParallelChecks">
+                        <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Maximum number of checks to run in parallel."></i>
+                    </label>
                     <input class="form-control" asp-for="Options.MaxParallelChecks" type="number" />
                 </div>
             </div>
         </div>
 
-        <button type="submit" class="btn btn-primary">Analizza</button>
+        <div class="position-relative">
+            <button type="submit" class="btn btn-primary">Analizza</button>
+            <div id="loading-overlay" class="d-none position-absolute top-50 start-50 translate-middle">
+                <div class="spinner-border" role="status">
+                    <span class="visually-hidden">Caricamento...</span>
+                </div>
+            </div>
+        </div>
     </form>
 
     @if (Model.Result != null)
     {
-        <div class="alert alert-info">
-            <h2>Risultato: @Model.Result.Verdict</h2>
-            <table class="table table-sm mb-0">
-                <thead>
-                    <tr><th>Punteggio totale</th><th>Soglia pulita</th><th>Soglia manomessa</th><th>Interpretazione</th></tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>@Model.Result.TotalScore.ToString("F2")</td>
-                        <td>@Model.Options.CleanThreshold</td>
-                        <td>@Model.Options.TamperedThreshold</td>
-                        <td>@Model.SpiegaPunteggio(Model.Result.TotalScore)</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-        @if (Model.Result.Errors.Count > 0)
-        {
-            <div class="alert alert-warning">
-                <h3>Errori dei controlli</h3>
-                <ul class="mb-0">
-                @foreach (var kv in Model.Result.Errors)
-                {
-                    <li><strong>@kv.Key</strong>: @kv.Value</li>
-                }
-                </ul>
+        <div id="result">
+            <div class="alert alert-info">
+                <h2>Risultato: @Model.Result.Verdict</h2>
+                <table class="table table-sm mb-0">
+                    <thead>
+                        <tr><th>Punteggio totale</th><th>Soglia pulita</th><th>Soglia manomessa</th><th>Interpretazione</th></tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>@Model.Result.TotalScore.ToString("F2")</td>
+                            <td>@Model.Options.CleanThreshold</td>
+                            <td>@Model.Options.TamperedThreshold</td>
+                            <td>@Model.SpiegaPunteggio(Model.Result.TotalScore)</td>
+                        </tr>
+                    </tbody>
+                </table>
             </div>
-        }
-        <div class="row g-4">
+            @if (Model.Result.Errors.Count > 0)
+            {
+                <div class="alert alert-warning">
+                    <h3>Errori dei controlli</h3>
+                    <ul class="mb-0">
+                    @foreach (var kv in Model.Result.Errors)
+                    {
+                        <li><strong>@kv.Key</strong>: @kv.Value</li>
+                    }
+                    </ul>
+                </div>
+            }
+            <div class="row g-4">
             <div class="col-md-6">
                 <div class="card h-100">
                     <div class="card-header">ELA</div>
@@ -206,13 +258,13 @@
                                 </tr>
                             </tbody>
                         </table>
-                        <img class="img-fluid mt-2" src="data:image/png;base64,@Model.ElaMapBase64" alt="Mappa ELA" />
+                        <img class="img-fluid mt-2" src="data:image/png;base64,@Model.ElaMapBase64" alt="ELA map" />
                     </div>
                 </div>
             </div>
             <div class="col-md-6">
                 <div class="card h-100">
-                    <div class="card-header">Copia e sposta</div>
+                    <div class="card-header">Copy-Move</div>
                     <div class="card-body">
                         <table class="table table-sm">
                             <thead><tr><th>Punteggio</th><th>Soglia pulita</th><th>Soglia manomessa</th><th>Interpretazione</th></tr></thead>
@@ -225,37 +277,15 @@
                                 </tr>
                             </tbody>
                         </table>
-                        <img class="img-fluid mt-2" src="data:image/png;base64,@Model.CopyMoveMapBase64" alt="Mappa copia e sposta" />
+                        <img class="img-fluid mt-2" src="data:image/png;base64,@Model.CopyMoveMapBase64" alt="Copy-Move map" />
                     </div>
                 </div>
             </div>
-            @if (!string.IsNullOrEmpty(Model.SplicingMapBase64))
-            {
-                <div class="col-md-6">
-                    <div class="card h-100">
-                        <div class="card-header">Giunzione</div>
-                        <div class="card-body">
-                            <table class="table table-sm">
-                                <thead><tr><th>Punteggio</th><th>Soglia pulita</th><th>Soglia manomessa</th><th>Interpretazione</th></tr></thead>
-                                <tbody>
-                                    <tr>
-                                        <td>@Model.Result.SplicingScore.ToString("F2")</td>
-                                        <td>@Model.Options.CleanThreshold</td>
-                                        <td>@Model.Options.TamperedThreshold</td>
-                                        <td>@Model.SpiegaPunteggio(Model.Result.SplicingScore)</td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                            <img class="img-fluid mt-2" src="data:image/png;base64,@Model.SplicingMapBase64" alt="Mappa giunzione" />
-                        </div>
-                    </div>
-                </div>
-            }
             @if (!string.IsNullOrEmpty(Model.InpaintingMapBase64))
             {
                 <div class="col-md-6">
                     <div class="card h-100">
-                        <div class="card-header">Riempimento</div>
+                        <div class="card-header">Inpainting</div>
                         <div class="card-body">
                             <table class="table table-sm">
                                 <thead><tr><th>Punteggio</th><th>Soglia pulita</th><th>Soglia manomessa</th><th>Interpretazione</th></tr></thead>
@@ -268,14 +298,14 @@
                                     </tr>
                                 </tbody>
                             </table>
-                            <img class="img-fluid mt-2" src="data:image/png;base64,@Model.InpaintingMapBase64" alt="Mappa riempimento" />
+                            <img class="img-fluid mt-2" src="data:image/png;base64,@Model.InpaintingMapBase64" alt="Inpainting map" />
                         </div>
                     </div>
                 </div>
             }
             <div class="col-12">
                 <div class="card">
-                    <div class="card-header">EXIF</div>
+                    <div class="card-header">Metadata</div>
                     <div class="card-body">
                         <table class="table table-sm mb-3">
                             <thead><tr><th>Punteggio</th><th>Soglia pulita</th><th>Soglia manomessa</th><th>Interpretazione</th></tr></thead>
@@ -307,5 +337,20 @@
     }
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const form = document.querySelector('form');
+        form.addEventListener('submit', function () {
+            document.getElementById('loading-overlay').classList.remove('d-none');
+            form.querySelector('button[type="submit"]').disabled = true;
+        });
+        const result = document.getElementById('result');
+        if (result) {
+            result.scrollIntoView({ behavior: 'smooth' });
+        }
+        const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+        tooltipTriggerList.forEach(t => new bootstrap.Tooltip(t));
+    });
+</script>
 </body>
 </html>

--- a/ImageForensic.Api/Pages/Index.cshtml.cs
+++ b/ImageForensic.Api/Pages/Index.cshtml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -28,11 +29,10 @@ public class IndexModel : PageModel
 
     public string ElaMapBase64 { get; private set; } = string.Empty;
     public string CopyMoveMapBase64 { get; private set; } = string.Empty;
-    public string SplicingMapBase64 { get; private set; } = string.Empty;
     public string InpaintingMapBase64 { get; private set; } = string.Empty;
 
-    public double DefaultCleanThreshold => new AnalyzeImageOptionsForm().CleanThreshold;
-    public double DefaultTamperedThreshold => new AnalyzeImageOptionsForm().TamperedThreshold;
+    public AnalyzeImageOptionsForm DefaultOptions { get; } = new();
+    public List<string> AvailableCameraModels { get; } = new() { "Canon EOS 80D", "Nikon D850" };
 
     public string SpiegaPunteggio(double punteggio)
     {
@@ -61,8 +61,6 @@ public class IndexModel : PageModel
         {
             WorkDir = workDir,
             CopyMoveMaskDir = workDir,
-            SplicingMapDir = workDir,
-            NoiseprintMapDir = workDir,
             MetadataMapDir = workDir
         };
 
@@ -72,7 +70,6 @@ public class IndexModel : PageModel
             Result = AnalyzeImageResult.From(res);
             ElaMapBase64 = Convert.ToBase64String(Result.ElaMap);
             CopyMoveMapBase64 = Convert.ToBase64String(Result.CopyMoveMask);
-            SplicingMapBase64 = Convert.ToBase64String(Result.SplicingMap);
             InpaintingMapBase64 = Convert.ToBase64String(Result.InpaintingMap);
         }
         catch (Exception ex)
@@ -90,65 +87,52 @@ public class IndexModel : PageModel
 
     public class AnalyzeImageOptionsForm
     {
-        [Display(Name = "Qualità ELA")]
+        [Display(Name = "ELA quality")]
         public int ElaQuality { get; set; } = 75;
 
-        [Display(Name = "Numero caratteristiche copia e sposta")]
+        [Display(Name = "Copy-Move feature count")]
         public int CopyMoveFeatureCount { get; set; } = 5000;
 
-        [Display(Name = "Distanza corrispondenza copia e sposta")]
+        [Display(Name = "Copy-Move match distance")]
         public double CopyMoveMatchDistance { get; set; } = 3.0;
 
-        [Display(Name = "RANSAC reproiezione copia e sposta")]
+        [Display(Name = "Copy-Move RANSAC reprojection")]
         public double CopyMoveRansacReproj { get; set; } = 3.0;
 
-        [Display(Name = "Probabilità RANSAC copia e sposta")]
+        [Display(Name = "Copy-Move RANSAC probability")]
         public double CopyMoveRansacProb { get; set; } = 0.99;
 
-        [Display(Name = "Larghezza input giunzione")]
-        public int SplicingInputWidth { get; set; } = 256;
+        [Display(Name = "Expected camera models")]
+        public List<string> ExpectedCameraModels { get; set; } = new() { "Canon EOS 80D", "Nikon D850" };
 
-        [Display(Name = "Altezza input giunzione")]
-        public int SplicingInputHeight { get; set; } = 256;
-
-        [Display(Name = "Dimensione input rumore")]
-        public int NoiseprintInputSize { get; set; } = 320;
-
-        [Display(Name = "Modelli fotocamera attesi")]
-        public string ExpectedCameraModels { get; set; } = "Canon EOS 80D,Nikon D850";
-
-        [Display(Name = "Peso ELA")]
+        [Display(Name = "ELA weight")]
         public double ElaWeight { get; set; } = 1.0;
 
-        [Display(Name = "Peso copia e sposta")]
+        [Display(Name = "Copy-Move weight")]
         public double CopyMoveWeight { get; set; } = 1.0;
 
-        [Display(Name = "Peso giunzione")]
-        public double SplicingWeight { get; set; } = 1.0;
-
-        [Display(Name = "Peso riempimento")]
+        [Display(Name = "Inpainting weight")]
         public double InpaintingWeight { get; set; } = 1.0;
 
-        [Display(Name = "Peso EXIF")]
+        [Display(Name = "Metadata weight")]
         public double ExifWeight { get; set; } = 1.0;
 
-        [Display(Name = "Soglia pulita")]
+        [Display(Name = "Clean threshold")]
         public double CleanThreshold { get; set; } = 0.2;
 
-        [Display(Name = "Soglia manomessa")]
+        [Display(Name = "Tampered threshold")]
         public double TamperedThreshold { get; set; } = 0.8;
 
-        [Display(Name = "Controlli abilitati")]
-        public string EnabledChecks { get; set; } = "Ela,CopyMove,Splicing,Inpainting,Exif";
+        [Display(Name = "Enabled checks")]
+        public List<string> EnabledChecks { get; set; } = new() { "Ela", "CopyMove", "Inpainting", "Exif" };
 
-        [Display(Name = "Numero massimo controlli paralleli")]
+        [Display(Name = "Max parallel checks")]
         public int MaxParallelChecks { get; set; } = 1;
 
         public AnalyzeImageOptions ToOptions()
         {
-            var enabled = EnabledChecks.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
             var flags = ForensicsCheck.None;
-            foreach (var e in enabled)
+            foreach (var e in EnabledChecks)
                 flags |= Enum.Parse<ForensicsCheck>(e, true);
 
             return new AnalyzeImageOptions
@@ -158,13 +142,9 @@ public class IndexModel : PageModel
                 CopyMoveMatchDistance = CopyMoveMatchDistance,
                 CopyMoveRansacReproj = CopyMoveRansacReproj,
                 CopyMoveRansacProb = CopyMoveRansacProb,
-                SplicingInputWidth = SplicingInputWidth,
-                SplicingInputHeight = SplicingInputHeight,
-                NoiseprintInputSize = NoiseprintInputSize,
-                ExpectedCameraModels = ExpectedCameraModels.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries),
+                ExpectedCameraModels = ExpectedCameraModels.ToArray(),
                 ElaWeight = ElaWeight,
                 CopyMoveWeight = CopyMoveWeight,
-                SplicingWeight = SplicingWeight,
                 InpaintingWeight = InpaintingWeight,
                 ExifWeight = ExifWeight,
                 CleanThreshold = CleanThreshold,


### PR DESCRIPTION
## Summary
- Replace numeric fields for weights and thresholds with range sliders
- Add metadata camera-model checkboxes and show default option values
- Include info icons and remove splicing/noiseprint controls

## Testing
- `dotnet test TestOpenCvSharp/TestOpenCvSharp.csproj -v n` *(fails: libgtk-x11-2.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_688cd97a12708325bc5bdb06ca136431