### PR TITLE
Adjust ELA default parameters

### DIFF
--- a/ImageForensic.Api/Models/AnalyzeImageOptions.cs
+++ b/ImageForensic.Api/Models/AnalyzeImageOptions.cs
@@ -4,11 +4,11 @@ namespace ImageForensic.Api;
 
 public record AnalyzeImageOptions
 {
-    public int ElaQuality { get; init; } = 75;
+    public int ElaQuality { get; init; } = 90;
     public int ElaWindowSize { get; init; } = 15;
     public double ElaK { get; init; } = 0.2;
-    public int ElaMinArea { get; init; } = 100;
-    public int ElaKernelSize { get; init; } = 5;
+    public int ElaMinArea { get; init; } = 50;
+    public int ElaKernelSize { get; init; } = 3;
 
     public int CopyMoveFeatureCount { get; init; } = 5000;
     public double CopyMoveMatchDistance { get; init; } = 3.0;
@@ -30,11 +30,11 @@ public record AnalyzeImageOptions
 
     public ForensicsOptions ToForensicsOptions() => new()
     {
-        ElaQuality = ElaQuality > 0 ? ElaQuality : 75,
+        ElaQuality = ElaQuality > 0 ? ElaQuality : 90,
         ElaWindowSize = ElaWindowSize > 0 ? ElaWindowSize : 15,
         ElaK = ElaK != 0 ? ElaK : 0.2,
-        ElaMinArea = ElaMinArea > 0 ? ElaMinArea : 100,
-        ElaKernelSize = ElaKernelSize > 0 ? ElaKernelSize : 5,
+        ElaMinArea = ElaMinArea > 0 ? ElaMinArea : 50,
+        ElaKernelSize = ElaKernelSize > 0 ? ElaKernelSize : 3,
         CopyMoveFeatureCount = CopyMoveFeatureCount,
         CopyMoveMatchDistance = CopyMoveMatchDistance,
         CopyMoveRansacReproj = CopyMoveRansacReproj,

--- a/ImageForensic.Api/Pages/Index.cshtml
+++ b/ImageForensic.Api/Pages/Index.cshtml
@@ -72,24 +72,28 @@
                         <div class="mb-3">
                             <label class="form-label" asp-for="Options.ElaWindowSize">
                                 @Html.DisplayNameFor(m => m.Options.ElaWindowSize)
+                                <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Size of the sliding window used to compute local variance."></i>
                             </label>
                             <input class="form-control" asp-for="Options.ElaWindowSize" type="number" />
                         </div>
                         <div class="mb-3">
                             <label class="form-label" asp-for="Options.ElaK">
                                 @Html.DisplayNameFor(m => m.Options.ElaK)
+                                <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Multiplier applied to the variance threshold for flagging anomalies."></i>
                             </label>
                             <input class="form-control" asp-for="Options.ElaK" type="number" step="0.01" />
                         </div>
                         <div class="mb-3">
                             <label class="form-label" asp-for="Options.ElaMinArea">
                                 @Html.DisplayNameFor(m => m.Options.ElaMinArea)
+                                <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Minimum connected area in pixels that a suspicious region must cover."></i>
                             </label>
                             <input class="form-control" asp-for="Options.ElaMinArea" type="number" />
                         </div>
                         <div class="mb-3">
                             <label class="form-label" asp-for="Options.ElaKernelSize">
                                 @Html.DisplayNameFor(m => m.Options.ElaKernelSize)
+                                <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Kernel size used to blur the ELA residual before thresholding."></i>
                             </label>
                             <input class="form-control" asp-for="Options.ElaKernelSize" type="number" />
                         </div>

--- a/ImageForensic.Api/Pages/Index.cshtml.cs
+++ b/ImageForensic.Api/Pages/Index.cshtml.cs
@@ -31,7 +31,7 @@ public class IndexModel : PageModel
     public string CopyMoveMapBase64 { get; private set; } = string.Empty;
     public string InpaintingMapBase64 { get; private set; } = string.Empty;
 
-    public AnalyzeImageOptionsForm DefaultOptions { get; } = new();
+    public AnalyzeImageOptionsForm DefaultOptions { get; } = new() { ElaQuality = 90, ElaMinArea = 50, ElaKernelSize = 3 };
     public List<string> AvailableCameraModels { get; } = new() { "Canon EOS 80D", "Nikon D850" };
     public Dictionary<ForensicsCheck, string> CheckDescriptions { get; } = new()
     {
@@ -95,7 +95,7 @@ public class IndexModel : PageModel
     public class AnalyzeImageOptionsForm
     {
         [Display(Name = "ELA quality")]
-        public int ElaQuality { get; set; } = 75;
+        public int ElaQuality { get; set; } = 90;
 
         [Display(Name = "ELA window size")]
         public int ElaWindowSize { get; set; } = 15;
@@ -104,10 +104,10 @@ public class IndexModel : PageModel
         public double ElaK { get; set; } = 0.2;
 
         [Display(Name = "ELA min area")]
-        public int ElaMinArea { get; set; } = 100;
+        public int ElaMinArea { get; set; } = 50;
 
         [Display(Name = "ELA kernel size")]
-        public int ElaKernelSize { get; set; } = 5;
+        public int ElaKernelSize { get; set; } = 3;
 
         [Display(Name = "Copy-Move feature count")]
         public int CopyMoveFeatureCount { get; set; } = 5000;

--- a/ImageForensics/src/ImageForensics.Core/Models/ForensicsOptions.cs
+++ b/ImageForensics/src/ImageForensics.Core/Models/ForensicsOptions.cs
@@ -17,11 +17,11 @@ public record ForensicsOptions
     public string SplicingModelPath  { get; init; } = "Models/onnx/mantranet_256x256.onnx";
     public string NoiseprintModelsDir { get; init; } = "Models/onnx/noiseprint";
 
-    public int ElaQuality { get; init; } = 75;
+    public int ElaQuality { get; init; } = 90;
     public int ElaWindowSize { get; init; } = 15;
     public double ElaK { get; init; } = 0.2;
-    public int ElaMinArea { get; init; } = 100;
-    public int ElaKernelSize { get; init; } = 5;
+    public int ElaMinArea { get; init; } = 50;
+    public int ElaKernelSize { get; init; } = 3;
 
     public int    CopyMoveFeatureCount  { get; init; } = 5000;
     public double CopyMoveMatchDistance { get; init; } = 3.0;


### PR DESCRIPTION
## Summary
- Raise default ELA quality to 90
- Reduce ELA min area to 50 and kernel size to 3
- Sync Index form defaults and default values table
- Add detailed tooltips for all advanced ELA options

## Testing
- `dotnet test image-forgery-scanner.sln -v n` *(fails: type or namespace 'Program' could not be found)*
- `dotnet test TestOpenCvSharp/TestOpenCvSharp.csproj -v n`


------
https://chatgpt.com/codex/tasks/task_e_688da3a4b1cc8325b0f06aecf55e5a6c