### PR TITLE
Restore splicing checks and translate web UI

### DIFF
--- a/ImageForensic.Api/Pages/Index.cshtml
+++ b/ImageForensic.Api/Pages/Index.cshtml
@@ -4,42 +4,47 @@
 @using System.Collections.Generic
 @using System.Linq
 <!DOCTYPE html>
-<html lang="it">
+<html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title>Analisi immagine</title>
+    <title>Image analysis</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" />
     <link rel="stylesheet" href="/css/site.css" />
 </head>
 <body class="bg-light">
 <div class="container py-5">
-    <h1 class="mb-4 text-center">Analisi immagine</h1>
+    <h1 class="mb-4 text-center">Image analysis</h1>
     <div class="mb-4">
         <button class="btn btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#defaultValues" aria-expanded="false" aria-controls="defaultValues">
-            Mostra valori di default
+            Show default values
         </button>
         <div class="collapse mt-2" id="defaultValues">
             <div class="card card-body">
                 <table class="table table-sm mb-0">
                     <thead>
-                        <tr><th>Opzione</th><th>Valore</th></tr>
+                        <tr><th>Option</th><th>Value</th></tr>
                     </thead>
                     <tbody>
-                        <tr><td>ELA quality</td><td>@Model.DefaultOptions.ElaQuality</td></tr>
-                        <tr><td>ELA window size</td><td>@Model.DefaultOptions.ElaWindowSize</td></tr>
-                        <tr><td>ELA k</td><td>@Model.DefaultOptions.ElaK</td></tr>
-                        <tr><td>ELA min area</td><td>@Model.DefaultOptions.ElaMinArea</td></tr>
-                        <tr><td>ELA kernel size</td><td>@Model.DefaultOptions.ElaKernelSize</td></tr>
-                        <tr><td>Copy-Move feature count</td><td>@Model.DefaultOptions.CopyMoveFeatureCount</td></tr>
-                        <tr><td>Copy-Move match distance</td><td>@Model.DefaultOptions.CopyMoveMatchDistance</td></tr>
-                        <tr><td>Copy-Move RANSAC reprojection</td><td>@Model.DefaultOptions.CopyMoveRansacReproj</td></tr>
-                        <tr><td>Copy-Move RANSAC probability</td><td>@Model.DefaultOptions.CopyMoveRansacProb</td></tr>
+                        <tr><th colspan="2">ELA</th></tr>
+                        <tr><td>Quality</td><td>@Model.DefaultOptions.ElaQuality</td></tr>
+                        <tr><td>Window size</td><td>@Model.DefaultOptions.ElaWindowSize</td></tr>
+                        <tr><td>K</td><td>@Model.DefaultOptions.ElaK</td></tr>
+                        <tr><td>Min area</td><td>@Model.DefaultOptions.ElaMinArea</td></tr>
+                        <tr><td>Kernel size</td><td>@Model.DefaultOptions.ElaKernelSize</td></tr>
+                        <tr><td>Weight</td><td>@Model.DefaultOptions.ElaWeight</td></tr>
+                        <tr><th colspan="2">Copy-Move</th></tr>
+                        <tr><td>Feature count</td><td>@Model.DefaultOptions.CopyMoveFeatureCount</td></tr>
+                        <tr><td>Match distance</td><td>@Model.DefaultOptions.CopyMoveMatchDistance</td></tr>
+                        <tr><td>RANSAC reprojection</td><td>@Model.DefaultOptions.CopyMoveRansacReproj</td></tr>
+                        <tr><td>RANSAC probability</td><td>@Model.DefaultOptions.CopyMoveRansacProb</td></tr>
+                        <tr><td>Weight</td><td>@Model.DefaultOptions.CopyMoveWeight</td></tr>
+                        <tr><th colspan="2">Inpainting</th></tr>
+                        <tr><td>Weight</td><td>@Model.DefaultOptions.InpaintingWeight</td></tr>
+                        <tr><th colspan="2">Metadata</th></tr>
                         <tr><td>Expected camera models</td><td>@string.Join(", ", Model.DefaultOptions.ExpectedCameraModels)</td></tr>
-                        <tr><td>ELA weight</td><td>@Model.DefaultOptions.ElaWeight</td></tr>
-                        <tr><td>Copy-Move weight</td><td>@Model.DefaultOptions.CopyMoveWeight</td></tr>
-                        <tr><td>Inpainting weight</td><td>@Model.DefaultOptions.InpaintingWeight</td></tr>
-                        <tr><td>Metadata weight</td><td>@Model.DefaultOptions.ExifWeight</td></tr>
+                        <tr><td>Weight</td><td>@Model.DefaultOptions.ExifWeight</td></tr>
+                        <tr><th colspan="2">General</th></tr>
                         <tr><td>Clean threshold</td><td>@Model.DefaultOptions.CleanThreshold</td></tr>
                         <tr><td>Tampered threshold</td><td>@Model.DefaultOptions.TamperedThreshold</td></tr>
                         <tr><td>Enabled checks</td><td>@string.Join(", ", Model.DefaultOptions.EnabledChecks.Select(c => c == "Exif" ? "Metadata" : c))</td></tr>
@@ -51,7 +56,7 @@
     </div>
     <form method="post" enctype="multipart/form-data" class="mb-5">
         <div class="mb-3">
-            <label class="form-label" asp-for="Image">Immagine <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Upload the image to analyze."></i></label>
+            <label class="form-label" asp-for="Image">Image <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Upload the image to analyze."></i></label>
             <input class="form-control" asp-for="Image" type="file" />
         </div>
 
@@ -66,7 +71,7 @@
                 </div>
                 <div>
                     <button class="btn btn-link p-0" type="button" data-bs-toggle="collapse" data-bs-target="#elaAdvanced" aria-expanded="false" aria-controls="elaAdvanced">
-                        Opzioni avanzate
+                        Advanced options
                     </button>
                     <div class="collapse mt-3" id="elaAdvanced">
                         <div class="mb-3">
@@ -150,7 +155,7 @@
         </div>
 
         <div class="card mb-3">
-            <div class="card-header">Pesi <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Weights used when combining individual scores."></i></div>
+            <div class="card-header">Weights <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Weights used when combining individual scores."></i></div>
             <div class="card-body">
                 <div class="row g-3">
                     <div class="col-md-6">
@@ -186,7 +191,7 @@
         </div>
 
         <div class="card mb-3">
-            <div class="card-header">Soglie <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Thresholds separating clean and tampered scores."></i></div>
+            <div class="card-header">Thresholds <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Thresholds separating clean and tampered scores."></i></div>
             <div class="card-body row g-3">
                 <div class="col-md-6">
                     <label class="form-label" asp-for="Options.CleanThreshold">
@@ -206,7 +211,7 @@
         </div>
 
         <div class="card mb-3">
-            <div class="card-header">Altre opzioni</div>
+            <div class="card-header">Other options</div>
             <div class="card-body row g-3">
                 <div class="col-md-6">
                     <label class="form-label">Enabled checks <i class="bi bi-info-circle ms-1" data-bs-toggle="tooltip" title="Select which analyses to run."></i></label>
@@ -234,10 +239,10 @@
         </div>
 
         <div class="position-relative">
-            <button type="submit" class="btn btn-primary">Analizza</button>
+            <button type="submit" class="btn btn-primary">Analyze</button>
             <div id="loading-overlay" class="d-none position-absolute top-50 start-50 translate-middle">
                 <div class="spinner-border" role="status">
-                    <span class="visually-hidden">Caricamento...</span>
+                    <span class="visually-hidden">Loading...</span>
                 </div>
             </div>
         </div>

--- a/ImageForensic.Api/Pages/Index.cshtml.cs
+++ b/ImageForensic.Api/Pages/Index.cshtml.cs
@@ -41,13 +41,13 @@ public class IndexModel : PageModel
         { ForensicsCheck.Exif, "Analyzes image metadata for anomalies." }
     };
 
-    public string SpiegaPunteggio(double punteggio)
+    public string ExplainScore(double score)
     {
-        if (punteggio < Options.CleanThreshold)
-            return $"Inferiore alla soglia di pulizia ({Options.CleanThreshold:F2}): il controllo non evidenzia manipolazioni.";
-        if (punteggio > Options.TamperedThreshold)
-            return $"Superiore alla soglia di manomissione ({Options.TamperedThreshold:F2}): il controllo suggerisce manomissioni.";
-        return $"Tra le soglie ({Options.CleanThreshold:F2}-{Options.TamperedThreshold:F2}): il risultato è incerto.";
+        if (score < Options.CleanThreshold)
+            return $"Below clean threshold ({Options.CleanThreshold:F2}): the check shows no tampering.";
+        if (score > Options.TamperedThreshold)
+            return $"Above tampered threshold ({Options.TamperedThreshold:F2}): the check suggests tampering.";
+        return $"Between thresholds ({Options.CleanThreshold:F2}-{Options.TamperedThreshold:F2}): the result is uncertain.";
     }
 
     public async Task<IActionResult> OnPostAsync()

--- a/ImageForensic.Api/Pages/_Result.cshtml
+++ b/ImageForensic.Api/Pages/_Result.cshtml
@@ -2,17 +2,17 @@
 
 <div id="result">
     <div class="alert alert-info">
-        <h2>Risultato: @Model.Result!.Verdict</h2>
+        <h2>Result: @Model.Result!.Verdict</h2>
         <table class="table table-sm mb-0">
             <thead>
-                <tr><th>Punteggio totale</th><th>Soglia pulita</th><th>Soglia manomessa</th><th>Interpretazione</th></tr>
+                <tr><th>Total score</th><th>Clean threshold</th><th>Tampered threshold</th><th>Interpretation</th></tr>
             </thead>
             <tbody>
                 <tr>
                     <td>@Model.Result!.TotalScore.ToString("F2")</td>
                     <td>@Model.Options.CleanThreshold</td>
                     <td>@Model.Options.TamperedThreshold</td>
-                    <td>@Model.SpiegaPunteggio(Model.Result!.TotalScore)</td>
+                    <td>@Model.ExplainScore(Model.Result!.TotalScore)</td>
                 </tr>
             </tbody>
         </table>
@@ -20,7 +20,7 @@
     @if (Model.Result!.Errors.Count > 0)
     {
         <div class="alert alert-warning">
-            <h3>Errori dei controlli</h3>
+            <h3>Check errors</h3>
             <ul class="mb-0">
             @foreach (var kv in Model.Result!.Errors)
             {
@@ -35,13 +35,13 @@
             <div class="card-header">ELA</div>
             <div class="card-body">
                 <table class="table table-sm">
-                    <thead><tr><th>Punteggio</th><th>Soglia pulita</th><th>Soglia manomessa</th><th>Interpretazione</th></tr></thead>
+                    <thead><tr><th>Score</th><th>Clean threshold</th><th>Tampered threshold</th><th>Interpretation</th></tr></thead>
                     <tbody>
                         <tr>
                             <td>@Model.Result!.ElaScore.ToString("F2")</td>
                             <td>@Model.Options.CleanThreshold</td>
                             <td>@Model.Options.TamperedThreshold</td>
-                            <td>@Model.SpiegaPunteggio(Model.Result!.ElaScore)</td>
+                            <td>@Model.ExplainScore(Model.Result!.ElaScore)</td>
                         </tr>
                     </tbody>
                 </table>
@@ -54,13 +54,13 @@
             <div class="card-header">Copy-Move</div>
             <div class="card-body">
                 <table class="table table-sm">
-                    <thead><tr><th>Punteggio</th><th>Soglia pulita</th><th>Soglia manomessa</th><th>Interpretazione</th></tr></thead>
+                    <thead><tr><th>Score</th><th>Clean threshold</th><th>Tampered threshold</th><th>Interpretation</th></tr></thead>
                     <tbody>
                         <tr>
                             <td>@Model.Result!.CopyMoveScore.ToString("F2")</td>
                             <td>@Model.Options.CleanThreshold</td>
                             <td>@Model.Options.TamperedThreshold</td>
-                            <td>@Model.SpiegaPunteggio(Model.Result!.CopyMoveScore)</td>
+                            <td>@Model.ExplainScore(Model.Result!.CopyMoveScore)</td>
                         </tr>
                     </tbody>
                 </table>
@@ -75,13 +75,13 @@
                 <div class="card-header">Inpainting</div>
                 <div class="card-body">
                     <table class="table table-sm">
-                        <thead><tr><th>Punteggio</th><th>Soglia pulita</th><th>Soglia manomessa</th><th>Interpretazione</th></tr></thead>
+                        <thead><tr><th>Score</th><th>Clean threshold</th><th>Tampered threshold</th><th>Interpretation</th></tr></thead>
                         <tbody>
                             <tr>
                                 <td>@Model.Result!.InpaintingScore.ToString("F2")</td>
                                 <td>@Model.Options.CleanThreshold</td>
                                 <td>@Model.Options.TamperedThreshold</td>
-                                <td>@Model.SpiegaPunteggio(Model.Result!.InpaintingScore)</td>
+                                <td>@Model.ExplainScore(Model.Result!.InpaintingScore)</td>
                             </tr>
                         </tbody>
                     </table>
@@ -95,20 +95,20 @@
             <div class="card-header">Metadata</div>
             <div class="card-body">
                 <table class="table table-sm mb-3">
-                    <thead><tr><th>Punteggio</th><th>Soglia pulita</th><th>Soglia manomessa</th><th>Interpretazione</th></tr></thead>
+                    <thead><tr><th>Score</th><th>Clean threshold</th><th>Tampered threshold</th><th>Interpretation</th></tr></thead>
                     <tbody>
                         <tr>
                             <td>@Model.Result!.ExifScore.ToString("F2")</td>
                             <td>@Model.Options.CleanThreshold</td>
                             <td>@Model.Options.TamperedThreshold</td>
-                            <td>@Model.SpiegaPunteggio(Model.Result!.ExifScore)</td>
+                            <td>@Model.ExplainScore(Model.Result!.ExifScore)</td>
                         </tr>
                     </tbody>
                 </table>
                 @if (Model.Result!.ExifAnomalies.Count > 0)
                 {
                     <table class="table table-sm mb-0">
-                        <thead><tr><th>Campo</th><th>Valore</th></tr></thead>
+                        <thead><tr><th>Field</th><th>Value</th></tr></thead>
                         <tbody>
                         @foreach (var kv in Model.Result!.ExifAnomalies)
                         {

--- a/ImageForensics/tests/ImageForensics.Tests/CliBenchmarkTests.cs
+++ b/ImageForensics/tests/ImageForensics.Tests/CliBenchmarkTests.cs
@@ -46,7 +46,13 @@ public class CliBenchmarkTests
         File.Exists(jsonPath).Should().BeTrue();
         var doc = JsonDocument.Parse(File.ReadAllText(jsonPath));
         var stats = doc.RootElement.GetProperty("Stats");
-        double avg = stats.GetProperty("ELA").GetProperty("Average").GetDouble();
-        avg.Should().BeGreaterThan(0);
+        double elaAvg = stats.GetProperty("ELA").GetProperty("Average").GetDouble();
+        elaAvg.Should().BeGreaterThan(0);
+        double spAvg = stats.GetProperty("Splicing").GetProperty("Average").GetDouble();
+        spAvg.Should().BeGreaterThan(0);
+        var results = doc.RootElement.GetProperty("Results");
+        results.GetArrayLength().Should().BeGreaterThan(0);
+        var first = results[0];
+        first.TryGetProperty("splicingScore", out _).Should().BeTrue();
     }
 }

--- a/ImageForensics/tests/ImageForensics.Tests/ErrorHandlingTests.cs
+++ b/ImageForensics/tests/ImageForensics.Tests/ErrorHandlingTests.cs
@@ -11,13 +11,17 @@ public class ErrorHandlingTests
     public async Task AnalyzerCollectsErrorsPerCheck()
     {
         var analyzer = new ForensicsAnalyzer();
+        string workDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         var options = new ForensicsOptions
         {
-            WorkDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()),
-            EnabledChecks = ForensicsCheck.Ela | ForensicsCheck.Exif
+            WorkDir = workDir,
+            SplicingMapDir = workDir,
+            SplicingModelPath = typeof(ErrorHandlingTests).Assembly.Location,
+            EnabledChecks = ForensicsCheck.Ela | ForensicsCheck.Splicing | ForensicsCheck.Exif
         };
         var result = await analyzer.AnalyzeAsync("missing.jpg", options);
         Assert.Contains("ELA", result.Errors.Keys);
+        Assert.Contains("Splicing", result.Errors.Keys);
         Assert.Contains("EXIF", result.Errors.Keys);
     }
 


### PR DESCRIPTION
## Summary
- ensure analyzer collects splicing errors alongside other checks
- verify CLI benchmark reports splicing stats and per-file splicing scores
- translate web interface to English and group default settings by check type

## Testing
- `dotnet test TestOpenCvSharp/TestOpenCvSharp.csproj -v n`
- `dotnet test ImageForensics/tests/ImageForensics.Tests/ImageForensics.Tests.csproj -v n --filter ErrorHandlingTests`
- `dotnet test ImageForensics/tests/ImageForensics.Tests/ImageForensics.Tests.csproj -v n` *(fails: Build failed with 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_688db3b318f0832593a50b5511309b37